### PR TITLE
Added .lower() at end of  output_format

### DIFF
--- a/aura/api_command.py
+++ b/aura/api_command.py
@@ -79,15 +79,15 @@ def api_command(name: str, help_text: str, fixed_cmd_output: str = None):
 
                 if data is None:
                     print("Operation successful")
-                elif output_format == "json":
+                elif output_format.lower() == "json":
                     print(json.dumps(data, indent=2))
-                elif output_format == "table":
+                elif output_format.lower() == "table":
                     out = format_table_output(data)
                     print(out)
-                elif output_format == "text":
+                elif output_format.lower() == "text":
                     out = format_text_output(data)
                     print(out)
-                elif output_format == "yaml":
+                elif output_format.lower() == "yaml":
                     print(yaml.dump(data))
                 else:
                     raise UnsupportedOutputFormat(output_format)


### PR DESCRIPTION
If a CLI user uses a capital letter in the output format option, it triggers an exception as it's not recognised

As there's no functionality impact from a user doing this, and it could be common e.g using Json instead of json, then changing output_format to be lower case for the comparison is a quick win for an improved user experience.