### PR TITLE
Increase aura cli timeout

### DIFF
--- a/aura/api_repository.py
+++ b/aura/api_repository.py
@@ -145,8 +145,12 @@ def make_api_call(method: str, path: str, **kwargs):
         " with data: " + json.dumps(kwargs["data"]) if "data" in kwargs else ""
     )
     logger.debug(f"Sending {method} request to {full_url}{data_string}")
+    
+    timeout = 10
+    if config.env.get("data_apis", False):
+        timeout = 30
 
-    response = requests.request(method, full_url, headers=headers, timeout=10, **kwargs)
+    response = requests.request(method, full_url, headers=headers, timeout=timeout, **kwargs)
     # If authentication failed, delete the token file to avoid using same token again
     if response.status_code in [401, 403]:
         logger.warning("API authentication failed.")

--- a/tests/unit/data_apis/test_create.py
+++ b/tests/unit/data_apis/test_create.py
@@ -78,7 +78,7 @@ def test_create_data_api_with_valid_type_definitions(api_request, mock_data_api_
             "Content-Type": "application/json",
             "Authorization": f"Bearer dummy-token",
         },
-        timeout=10,
+        timeout=30,
         data=json.dumps(
             {
                 "name": name,
@@ -200,7 +200,7 @@ def test_create_data_api_with_valid_type_definitions_file(
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer dummy-token",
             },
-            timeout=10,
+            timeout=30,
             data=json.dumps(
                 {
                     "name": name,
@@ -332,7 +332,7 @@ def test_create_data_api_with_jwks_url(api_request, mock_data_api_config):
             "Content-Type": "application/json",
             "Authorization": f"Bearer dummy-token",
         },
-        timeout=10,
+        timeout=30,
         data=json.dumps(
             {
                 "name": name,

--- a/tests/unit/data_apis/test_delete.py
+++ b/tests/unit/data_apis/test_delete.py
@@ -52,5 +52,5 @@ def test_delete_data_api(api_request, mock_data_api_config):
             "Content-Type": "application/json",
             "Authorization": f"Bearer dummy-token",
         },
-        timeout=10,
+        timeout=30,
     )

--- a/tests/unit/data_apis/test_get.py
+++ b/tests/unit/data_apis/test_get.py
@@ -52,5 +52,5 @@ def test_get_data_api(api_request, mock_data_api_config):
             "Content-Type": "application/json",
             "Authorization": f"Bearer dummy-token",
         },
-        timeout=10,
+        timeout=30,
     )

--- a/tests/unit/data_apis/test_list.py
+++ b/tests/unit/data_apis/test_list.py
@@ -56,5 +56,5 @@ def test_list_data_apis(api_request, mock_data_api_config):
             "Content-Type": "application/json",
             "Authorization": f"Bearer dummy-token",
         },
-        timeout=10,
+        timeout=30,
     )

--- a/tests/unit/data_apis/test_update.py
+++ b/tests/unit/data_apis/test_update.py
@@ -71,7 +71,7 @@ def test_update_data_api(api_request, mock_data_api_config):
             "Content-Type": "application/json",
             "Authorization": f"Bearer dummy-token",
         },
-        timeout=10,
+        timeout=30,
         data=json.dumps(
             {
                 "name": name,
@@ -129,7 +129,7 @@ def test_update_data_api_type_definitions(api_request, mock_data_api_config):
             "Content-Type": "application/json",
             "Authorization": f"Bearer dummy-token",
         },
-        timeout=10,
+        timeout=30,
         data=json.dumps(
             {"type_definitions": base64.b64encode(type_definitions.encode()).decode()}
         ),
@@ -192,7 +192,7 @@ def test_update_data_api_two_calls(api_request, mock_data_api_config):
             "Content-Type": "application/json",
             "Authorization": f"Bearer dummy-token",
         },
-        timeout=10,
+        timeout=30,
         data=json.dumps(
             {
                 "name": name,
@@ -211,7 +211,7 @@ def test_update_data_api_two_calls(api_request, mock_data_api_config):
             "Content-Type": "application/json",
             "Authorization": f"Bearer dummy-token",
         },
-        timeout=10,
+        timeout=30,
         data=json.dumps(
             {"type_definitions": base64.b64encode(type_definitions.encode()).decode()}
         ),
@@ -280,7 +280,7 @@ def test_update_data_api_two_calls_with_type_definitions_file(
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer dummy-token",
             },
-            timeout=10,
+            timeout=30,
             data=json.dumps(
                 {
                     "name": name,
@@ -299,7 +299,7 @@ def test_update_data_api_two_calls_with_type_definitions_file(
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer dummy-token",
             },
-            timeout=10,
+            timeout=30,
             data=json.dumps(
                 {
                     "type_definitions": base64.b64encode(

--- a/tests/unit/test_api_repository.py
+++ b/tests/unit/test_api_repository.py
@@ -12,6 +12,13 @@ def mock_context(mock_config):
     with patch("click.get_current_context", return_value=mock_context):
         yield
 
+@pytest.fixture
+def mock_data_api_context(mock_data_api_config):
+    mock_context = MagicMock()
+    mock_context.obj = mock_data_api_config
+    with patch("click.get_current_context", return_value=mock_context):
+        yield
+
 
 def test_get_headers(mock_version):
     with patch("aura.api_repository._authenticate", return_value="mock_token"):
@@ -39,6 +46,23 @@ def test_make_api_call(api_request, get_headers, mock_context):
             "Authorization": "Bearer dummy-token",
         },
         timeout=10,
+    )
+
+def test_make_data_api_call(api_request, get_headers, mock_data_api_context):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    api_request.return_value = mock_response
+
+    make_api_call("GET", "/instances")
+
+    api_request.assert_called_once_with(
+        "GET",
+        "https://graphql-api-staging.neo4j.io/v1/instances",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": "Bearer dummy-token",
+        },
+        timeout=30,
     )
 
 


### PR DESCRIPTION
The provisioning API for Data APIs can have requests that take up to 30 seconds to respond (obviously we want to improve this in the future). For now, this PR increases the timeout for such requests so that they can be served